### PR TITLE
feat(hooks): 添加 useAsync 钩子支持异步操作

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "lit-fn",
-	"version": "0.2.2-fix",
+	"version": "0.2.3",
 	"type": "module",
 	"scripts": {
 		"dev": "vite",

--- a/src/fwc.ts
+++ b/src/fwc.ts
@@ -9,7 +9,7 @@ import {
 } from "lit";
 
 // ---------------------------
-// Hook 系统相关类型 & 函数
+// Hook System Types & Functions (keep as is, or in a separate file)
 // ---------------------------
 export type HookContainer = {
 	states: any[];
@@ -32,7 +32,6 @@ export function resetHooks() {
 	currentContainer.currentIndex = 0;
 }
 
-// withContainer 必须在 component 调用之前就声明
 function withContainer<T>(container: HookContainer, fn: () => T): T {
 	const prev = currentContainer;
 	currentContainer = container;
@@ -44,9 +43,8 @@ function withContainer<T>(container: HookContainer, fn: () => T): T {
 }
 
 // ---------------------------
-// 工具类型声明
+// Utility Types (keep as is)
 // ---------------------------
-
 type ComponentFn<T = any> =
 	| ((props: T, ctx: ComponentContext<T>) => TemplateResult)
 	| ((props: T, ctx: ComponentContext<T>) => () => TemplateResult);
@@ -64,10 +62,9 @@ type LowercaseDashString<T extends string> = T extends `${string}-${string}`
 	: never;
 type TagOptions<T extends string> = {
 	name: LowercaseDashString<T>;
-	extends: keyof HTMLElementTagNameMap;
+	extends?: keyof HTMLElementTagNameMap; // Changed to optional as per usage
 };
 
-// ComponentClass / ComponentContext 接口，与之前保持一致
 export interface ComponentClass<T> {
 	get tag(): string;
 	get props(): T;
@@ -76,105 +73,125 @@ export interface ComponentClass<T> {
 export interface ComponentContext<T> extends ComponentClass<T> {
 	onAdopted: (callback: () => void | Promise<void>) => void;
 	lazy<Args extends any[]>(
-		callback: () => (...args: Args) => TemplateResult
+		callback: () => (...args: Args) => TemplateResult,
+		fallback?: TemplateResult | ((e: Error) => TemplateResult)
 	): (...args: Args) => TemplateResult;
+	injectFields<Fields extends Record<string, any>>(
+		fields: Fields
+	): ComponentContext<T> & { readonly [P in keyof Fields]: Fields[P] };
 }
 
+// ---------------------------
+// Helper Functions for Component Definition
+// ---------------------------
+
+function normalizeTagName<Name extends string>(
+	tag: LowercaseDashString<Name> | TagOptions<Name>
+): LowercaseDashString<Name> {
+	return (tag as TagOptions<Name>)?.name || (tag as LowercaseDashString<Name>);
+}
+
+function getLitStaticProperties<T>(observedProps: (keyof T)[]): {
+	[key: string]: PropertyDeclaration;
+} {
+	const staticProps: { [key: string]: PropertyDeclaration } = {};
+	observedProps.forEach((key) => {
+		staticProps[key as string] = { type: Object };
+	});
+	return staticProps;
+}
+
+function getLitStaticStyles(
+	styleOptions?: ComponentOptions["style"]
+): CSSResult | CSSResult[] | undefined {
+	if (!styleOptions) return undefined;
+	if (Array.isArray(styleOptions)) {
+		return styleOptions.map((s) =>
+			typeof s === "string" ? css([s] as any) : s
+		);
+	} else if (typeof styleOptions === "string") {
+		return css([styleOptions] as any);
+	} else {
+		return styleOptions;
+	}
+}
+
+// ---------------------------
+// Main Component Definition Logic
+// ---------------------------
 export function defineComponent<T, Name extends string>(
 	tag: LowercaseDashString<Name> | TagOptions<Name>,
 	component: ComponentFn<T>,
 	options?: ComponentOptions<T>
 ): ComponentClass<T> & LitElement {
-	// 1. 规范化 tagName
-	const tagName =
-		(tag as TagOptions<Name>)?.name || (tag as LowercaseDashString<Name>);
+	const tagName = normalizeTagName(tag);
 
-	// 如果已注册过，直接返回
 	if (customElements.get(tagName)) {
 		return customElements.get(tagName) as unknown as ComponentClass<T> &
 			LitElement;
 	}
 
-	// 2. 从 options.props 里构造 LitElement 的 static properties
 	const observedProps = options?.props || [];
-	const staticProps: { [key: string]: PropertyDeclaration } = {};
-	observedProps.forEach((key) => {
-		staticProps[key as string] = { type: Object };
-	});
-
-	// 3. 收集 style 到 LitElement 的 static styles
-	let combinedStyles: CSSResult | CSSResult[] | undefined;
-	if (options?.style) {
-		if (Array.isArray(options.style)) {
-			combinedStyles = options.style.map((s) =>
-				typeof s === "string" ? css([s] as any) : s
-			);
-		} else if (typeof options.style === "string") {
-			combinedStyles = css([options.style] as any);
-		} else {
-			combinedStyles = options.style;
-		}
-	}
-
-	// 4. mixinFn：如果用户想把 LitElement 再包一层 mixin，可以传入
+	const staticProps = getLitStaticProperties(observedProps);
+	const combinedStyles = getLitStaticStyles(options?.style);
 	const BaseClass = options?.mixinFn ? options.mixinFn(LitElement) : LitElement;
 
 	class FunctionElement
 		extends BaseClass
 		implements ComponentClass<T>, ComponentContext<T>
 	{
-		// 4.1 把 static properties 和 static styles 挂在类上
-		static get properties() {
-			return staticProps;
-		}
+		static properties = staticProps;
 		static styles = combinedStyles;
 
-		// Hook 容器
 		private hookContainer: HookContainer;
-
-		// 存储 <template slot="..."> … </template> 的内容
 		private templates: Record<string, HTMLTemplateElement> = {};
-
-		// onAdopted 回调队列
-		private __onAdopted: Array<() => void | Promise<void>> = [];
+		private __onAdoptedCallbacks: Array<() => void | Promise<void>> = [];
 
 		constructor() {
 			super();
-			// 初始化 HookContainer
 			this.hookContainer = {
 				states: [],
 				effectHooks: [],
 				memoHooks: [],
 				cleanups: [],
 				currentIndex: 0,
-				rerender: () => {
-					// 当 Hook 调用 injectRerender 时，LitElement.requestUpdate() 负责重新渲染
-					this.requestUpdate();
-				},
+				rerender: () => this.requestUpdate(),
 			};
 		}
-
-		// ---------------------------
-		// ComponentClass & ComponentContext 实现
-		// ---------------------------
 
 		get tag(): string {
 			return tagName;
 		}
 
 		get props(): T {
-			// LitElement 会把属性自动映射到实例上，所以直接把 this 断言成 T
 			return this as unknown as T;
 		}
 
 		onAdopted(callback: () => void | Promise<void>) {
 			if (typeof callback === "function") {
-				this.__onAdopted.push(callback);
+				this.__onAdoptedCallbacks.push(callback);
 			}
 		}
 
+		injectFields<Fields extends Record<string, any>>(
+			fields: Fields
+		): ComponentContext<T> & Readonly<{ [P in keyof Fields]: Fields[P] }> {
+			const self = this as unknown as ComponentContext<T> &
+				Readonly<{ [P in keyof Fields]: Fields[P] }>;
+			Object.entries(fields).forEach(([key, value]) => {
+				if (Object.prototype.hasOwnProperty.call(self, key)) return;
+				Object.defineProperty(self, key, {
+					value,
+					writable: false,
+					configurable: true,
+				});
+			});
+			return self;
+		}
+
 		public lazy<Args extends any[]>(
-			callback: () => (...args: Args) => TemplateResult
+			callback: () => (...args: Args) => TemplateResult,
+			fallback?: TemplateResult | ((e: Error) => TemplateResult) // Added fallback
 		): (...args: Args) => TemplateResult {
 			const _callback = (callback ?? (() => callback)) as () => (
 				...args: Args
@@ -183,22 +200,22 @@ export function defineComponent<T, Name extends string>(
 				try {
 					return _callback().apply(this, args);
 				} catch (e) {
+					console.error("Lazy component error:", e); // Log the error
 					setTimeout(() => {
 						this.requestUpdate();
 					}, 0);
-					return html`<!-- lazy component error: ${(e as Error).message} -->`;
+					if (fallback) {
+						return typeof fallback === "function"
+							? fallback(e as Error)
+							: fallback;
+					}
+					return html``;
 				}
 			};
 		}
 
-		// ---------------------------
-		// 覆写 LitElement 的生命周期
-		// ---------------------------
-
 		connectedCallback() {
 			super.connectedCallback();
-
-			// 提取 <template slot="xxx">…</template> 内容
 			Array.from(this.children).forEach((node) => {
 				if (node.nodeName === "TEMPLATE") {
 					const tpl = node as HTMLTemplateElement;
@@ -208,34 +225,24 @@ export function defineComponent<T, Name extends string>(
 				}
 			});
 
-			// 首次挂载时，只要让 HookContainer 初始化一次即可，后续全部走 render()
 			withContainer(this.hookContainer, () => {
 				resetHooks();
-				// 仅初始化 Hook，不实际渲染。真正渲染由 LitElement 调用 render() 完成
 			});
 		}
 
 		disconnectedCallback() {
 			super.disconnectedCallback();
-			// 执行所有注册到 HookContainer 上的 cleanup
 			this.hookContainer.cleanups.forEach((fn) => {
 				if (typeof fn === "function") fn();
 			});
 		}
 
-		// LitElement 没有把 adoptedCallback 声明到类型里，直接用 @ts-ignore 绕过
-		// 当这个元素被移动到另一个 document 时，会调用 adoptedCallback
-		// 在这里把所有 onAdopted 回调执行完
-		// 再次触发一次更新
-		// tslint:disable-next-line: no-unused-variable
 		// @ts-ignore
 		adoptedCallback() {
-			// 虽然 LitElement 类型声明里没有 adoptedCallback，但它确实会被调用
-			// 我们用 @ts-ignore 忽略类型检查
 			(async () => {
 				const asyncTasks: Array<Promise<void>> = [];
 				const syncTasks: Array<() => void> = [];
-				for (const cb of this.__onAdopted) {
+				for (const cb of this.__onAdoptedCallbacks) {
 					if (cb.constructor.name === "AsyncFunction") {
 						asyncTasks.push(Promise.resolve(cb()));
 					} else {
@@ -248,28 +255,21 @@ export function defineComponent<T, Name extends string>(
 			})();
 		}
 
-		// LitElement 在属性（props）变化时，会自动触发 shouldUpdate → render → updateComplete
-		// 我们保持默认的 shouldUpdate 逻辑
 		protected shouldUpdate(_changedProps: PropertyValues): boolean {
 			return super.shouldUpdate(_changedProps);
 		}
 
-		// 真正的渲染：把用户的 component(props, ctx) 的输出交给 LitElement
 		protected render(): TemplateResult {
-			// tpl 可能是 TemplateResult，或者是 ()=>TemplateResult。先用 ! 告诉 TS 我们肯定会给它赋值
 			let tpl!: TemplateResult | (() => TemplateResult);
 
-			// 在 render 里，把 currentContainer 设置为 this.hookContainer，从而支持所有 Hook
 			withContainer(this.hookContainer, () => {
 				resetHooks();
 				tpl = component(this.props, this as unknown as ComponentContext<T>);
 			});
 
-			// 如果用户返回了函数，就执行它
 			const finalTpl: TemplateResult =
 				typeof tpl === "function" ? (tpl as () => TemplateResult)() : tpl;
 
-			// 如果存在 <template slot="..."> 内容，把它们拼接到最后
 			if (Object.keys(this.templates).length > 0) {
 				return html`
 					<div>
@@ -291,7 +291,6 @@ export function defineComponent<T, Name extends string>(
 		}
 	}
 
-	// 如果指定了 extends，就用第二个参数形式注册（例如 <button is="my-button">）
 	if ((tag as TagOptions<Name>)?.extends) {
 		customElements.define(tagName, FunctionElement, {
 			extends: (tag as TagOptions<Name>).extends,

--- a/src/hooks/adapter/index.ts
+++ b/src/hooks/adapter/index.ts
@@ -2,6 +2,7 @@ import { hooksAdapter } from "@/_adaper";
 import {
 	currentContainer,
 	EventBus,
+	UseAsyncReturn,
 	type Context as Ctx,
 	type EffectFn as effn,
 } from "../core";
@@ -77,6 +78,13 @@ export interface HooksAdapterInterface {
 	// ==== async ====
 	useTimeout(fn: () => void, delay: number): void;
 	useInterval(fn: () => void, interval: number): void;
+	useAsync<T = any, P extends any[] = any[]>(
+		asyncFunction: (...params: P) => Promise<T>,
+		option: {
+			immediate?: boolean;
+			initialParams?: P;
+		}
+	): UseAsyncReturn<T, P>;
 	useDebounce<T>(value: T, wait: number): T;
 	useThrottle<T>(value: T, limit: number): T;
 	useDebounceFn<T extends (...args: any[]) => any>(

--- a/src/hooks/core.ts
+++ b/src/hooks/core.ts
@@ -34,3 +34,14 @@ export class EventBus<Payload = any> {
 export function createUUID(): string {
 	return crypto.randomUUID();
 }
+
+export type AsyncState<T> = {
+	loading: boolean;
+	data: T | null;
+	error: Error | null;
+};
+
+export type UseAsyncReturn<T, P extends any[]> = AsyncState<T> & {
+	run: (...params: P) => Promise<T | undefined>;
+	reset: () => void;
+};

--- a/src/hooks/effect/index.ts
+++ b/src/hooks/effect/index.ts
@@ -1,4 +1,4 @@
-import { hooksAdapter } from "@/_adaper";
+import { hooksAdapter } from "../../_adaper";
 import { currentContainer, type EffectFn } from "../core";
 import { useRef as BuseRef } from "../ref";
 const useRef = () => hooksAdapter.current?.useRef ?? BuseRef;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -163,6 +163,14 @@ export const useInterval = (fn: () => void, interval: number) =>
 export const useDebounce = <T>(value: T, wait: number) =>
 	(hooksAdapter.current?.useDebounce ?? basic.useDebounce)(value, wait);
 
+export const useAsync = <T = any, P extends any[] = any[]>(
+	asyncFunction: (...params: P) => Promise<T>,
+	option: {
+		immediate?: boolean;
+		initialParams?: P;
+	}
+) => (hooksAdapter.current?.useAsync ?? basic.useAsync)(asyncFunction, option);
+
 export const useThrottle = <T>(value: T, limit: number) =>
 	(hooksAdapter.current?.useThrottle ?? basic.useThrottle)(value, limit);
 

--- a/src/stories/async-data-component.stories.ts
+++ b/src/stories/async-data-component.stories.ts
@@ -1,0 +1,39 @@
+import type { Meta } from "@storybook/web-components";
+import { html } from "lit";
+import { AsyncDataComponent } from "./async-data-component";
+AsyncDataComponent.register("async-data-component");
+// 注册主组件
+
+// 默认 URL 参数
+const DEFAULT_URL = "https://jsonplaceholder.typicode.com/posts/1";
+
+// 可配置的组件模板
+const AppMainShow = (args: any) => {
+	return html` <async-data-component .url=${args.url}></async-data-component> `;
+};
+
+// Story 配置
+const meta = {
+	title: "LitFn/useAsync",
+	tags: ["autodocs"],
+	render: (args) => {
+		return AppMainShow(args);
+	},
+	argTypes: {
+		url: {
+			control: "text",
+			name: "URL",
+			description: "要请求的数据地址",
+			defaultValue: DEFAULT_URL,
+		},
+	},
+} satisfies Meta;
+
+export default meta;
+
+// 默认故事
+export const Show = {
+	args: {
+		url: DEFAULT_URL,
+	},
+};

--- a/src/stories/async-data-component.ts
+++ b/src/stories/async-data-component.ts
@@ -1,0 +1,63 @@
+// 文件: src/components/async-data-component.ts
+import { useEffect } from "@/hooks/effect";
+import { css, html } from "lit";
+import { createComponent } from "../fwc";
+import { useAsync } from "../hooks/async";
+
+// 定义 props 类型
+interface AsyncDataProps {
+	url: string;
+}
+
+// 定义组件
+export const AsyncDataComponent = createComponent<AsyncDataProps>(
+	(props, _) => {
+		// 使用 useAsync Hook 获取数据
+		const { loading, error, data, run } = useAsync(
+			async () => {
+				const res = await fetch(props.url);
+				if (!res.ok) throw new Error("请求失败");
+				return res.json();
+			},
+			{
+				immediate: true,
+			}
+		);
+		useEffect(() => {
+			run();
+		}, [props.url]);
+
+		// 根据状态渲染不同 UI
+		if (loading) {
+			return html`<div>加载中...</div>`;
+		}
+
+		if (error) {
+			return html`<div style="color: red;">错误: ${error.message}</div>`;
+		}
+
+		return html`
+			<div>
+				<h3>获取到的数据：</h3>
+				<pre>${JSON.stringify(data, null, 2)}</pre>
+			</div>
+		`;
+	},
+	{
+		props: ["url"],
+		style: css`
+			:host {
+				display: block;
+				padding: 1em;
+				border: 1px solid #ddd;
+				border-radius: 4px;
+				font-family: sans-serif;
+			}
+			pre {
+				background: #f9f9f9;
+				padding: 1em;
+				overflow-x: auto;
+			}
+		`,
+	}
+);


### PR DESCRIPTION
- 新增 useAsync 钩子，用于处理异步请求
- 在 hooks/async 目录下实现 useAsync 函数
- 更新 hooks/index.ts，导出 useAsync 供外部使用
- 修改 hooks/core.ts，定义 UseAsyncReturn 类型